### PR TITLE
Documentation: `Configurations` folder (2nd batch) + `Values` leftover

### DIFF
--- a/Sources/SnappDesignTokens/Configurations/MeasurementValueEncodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/MeasurementValueEncodingConfiguration.swift
@@ -6,7 +6,33 @@
 
 import Foundation
 
+/// Configuration for encoding ``TokenMeasurement`` values.
+///
+/// Controls output format for measurements combining numeric values with units
+/// (dimensions, durations). Supports DTCG-compliant object format or compact
+/// value-only representations.
+///
+/// Used by:
+/// - ``DimensionConstant`` (value+unit or bare number)
+/// - ``DurationValue`` (value+unit or bare number)
+///
+/// Example:
+/// ```swift
+/// let measurement = TokenMeasurement(value: 16, unit: DimensionUnit.px)
+///
+/// // .default => {"value": 16, "unit": "px"}
+/// // .value(withUnit: true) => "16px"
+/// // .value(withUnit: false) => 16
+/// ```
 public enum MeasurementValueEncodingConfiguration: Equatable, Sendable {
+    /// Standard DTCG object format with separate value and unit properties.
+    ///
+    /// Encodes as object: `{"value": 16, "unit": "px"}`
     case `default`
+
+    /// Compact value format, optionally including unit suffix.
+    ///
+    /// - Parameter withUnit: When `true`, encodes as string with unit suffix (e.g., `"16px"`).
+    ///   When `false`, encodes as bare number (e.g., `16`).
     case value(withUnit: Bool = false)
 }

--- a/Sources/SnappDesignTokens/Configurations/TokenDecodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenDecodingConfiguration.swift
@@ -6,13 +6,55 @@
 
 import Foundation
 
+/// Configuration for decoding DTCG token files.
+///
+/// Controls token parsing behavior including file value decoding, type inheritance
+/// from parent groups, and custom type mappings for non-standard token types.
+///
+/// Set on ``JSONDecoder`` via `tokenDecodingConfiguration` property:
+/// ```swift
+/// let decoder = JSONDecoder()
+/// decoder.tokenDecodingConfiguration = TokenDecodingConfiguration(
+///     file: .base64,
+///     customTypeMapping: [.custom("icon"): .file]
+/// )
+/// let tokens = try decoder.decode(Token.self, from: data)
+/// ```
 public struct TokenDecodingConfiguration: Equatable, Sendable {
+    /// Default configuration with no customizations.
     public static let `default` = Self()
 
+    /// File value decoding configuration as ``FileValueDecodingConfiguration``.
+    ///
+    /// Controls how file token values are decoded (e.g., base64 embedded data).
     public let fileDecodingConfiguration: FileValueDecodingConfiguration?
+
+    /// Parent token type inherited from containing group.
+    ///
+    /// Automatically set during decoding when a token group has a `$type` property.
+    /// Child tokens inherit this type unless they specify their own.
     public var parentType: TokenType?
+
+    /// Custom token type mappings for non-standard types.
+    ///
+    /// Maps custom type names to standard DTCG types. Enables parsing tokens
+    /// with vendor-specific type names (e.g., `icon` → `file`).
+    ///
+    /// Example:
+    /// ```swift
+    /// customTypeMapping: [
+    ///     .custom("icon"): .file,
+    ///     .custom("spacing"): .dimension
+    /// ]
+    /// ```
     public let customTypeMapping: [TokenType: TokenType]?
 
+    /// Creates a token decoding configuration.
+    ///
+    /// - Parameters:
+    ///   - fileDecodingConfiguration: File value decoding configuration (optional)
+    ///   - parentType: Parent token type (optional, set automatically during decoding)
+    ///   - customTypeMapping: Custom type mappings dictionary (optional)
     public init(
         file fileDecodingConfiguration: FileValueDecodingConfiguration? =
             nil,

--- a/Sources/SnappDesignTokens/Configurations/TokenEncodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenEncodingConfiguration.swift
@@ -6,12 +6,37 @@
 
 import Foundation
 
+/// Configuration for encoding tokens to JSON.
+///
+/// Controls token output format including value encoding styles for colors,
+/// files, and measurements. Enables customization of output format while
+/// maintaining DTCG compliance or generating compact representations.
+///
+/// Set on ``JSONEncoder`` via `tokenEncodingConfiguration` property:
+/// ```swift
+/// let encoder = JSONEncoder()
+/// encoder.tokenEncodingConfiguration = TokenEncodingConfiguration(
+///     tokenValue: TokenValueEncodingConfiguration(
+///         color: .hex,
+///         measurement: .value(withUnit: true)
+///     )
+/// )
+/// let data = try encoder.encode(token)
+/// ```
 public struct TokenEncodingConfiguration: Equatable, Sendable {
+    /// Default configuration with standard DTCG-compliant output.
     public static let `default` = Self()
 
+    /// Token value encoding configuration as ``TokenValueEncodingConfiguration``.
+    ///
+    /// Controls encoding format for individual token value types (colors,
+    /// files, measurements). When `nil`, uses default formats.
     public let tokenValueEncodingConfiguration:
         TokenValueEncodingConfiguration?
 
+    /// Creates a token encoding configuration.
+    ///
+    /// - Parameter tokenValueEncodingConfiguration: Value encoding configuration (optional)
     public init(
         tokenValue tokenValueEncodingConfiguration:
             TokenValueEncodingConfiguration? = nil

--- a/Sources/SnappDesignTokens/Configurations/TokenValueDecodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenValueDecodingConfiguration.swift
@@ -6,11 +6,44 @@
 
 import Foundation
 
+/// Configuration for decoding token values.
+///
+/// Controls value-level decoding behavior including type specification, file
+/// value decoding, and custom type mappings. Used internally during token
+/// parsing to pass decoding context.
+///
+/// Typically created automatically during decoding but can be set explicitly:
+/// ```swift
+/// let config = TokenValueDecodingConfiguration(
+///     type: .dimension,
+///     file: .base64,
+///     customTypeMapping: [.custom("icon"): .file]
+/// )
+/// ```
 public struct TokenValueDecodingConfiguration: Equatable, Sendable {
+    /// Expected token type for this value as ``TokenType``.
+    ///
+    /// When set, the decoder expects the value to be of this type. Inherited
+    /// from parent group `$type` or explicit token `$type` property.
     public let type: TokenType?
+
+    /// File value decoding configuration as ``FileValueDecodingConfiguration``.
+    ///
+    /// Controls how file token values are decoded (e.g., base64 embedded data).
     public let fileDecodingConfiguration: FileValueDecodingConfiguration?
+
+    /// Custom token type mappings for non-standard types.
+    ///
+    /// Maps custom type names to standard DTCG types. Enables parsing tokens
+    /// with vendor-specific type names.
     public let customTypeMapping: [TokenType: TokenType]?
 
+    /// Creates a token value decoding configuration.
+    ///
+    /// - Parameters:
+    ///   - type: Expected token type (optional)
+    ///   - fileDecodingConfiguration: File value decoding configuration (optional)
+    ///   - customTypeMapping: Custom type mappings dictionary (optional)
     public init(
         type: TokenType?,
         file fileDecodingConfiguration: FileValueDecodingConfiguration?,

--- a/Sources/SnappDesignTokens/Configurations/TokenValueEncodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenValueEncodingConfiguration.swift
@@ -6,13 +6,51 @@
 
 import Foundation
 
+/// Configuration for encoding token values.
+///
+/// Aggregates encoding configurations for specific value types (colors, files,
+/// measurements). Controls output format at value level while maintaining
+/// flexibility across different token types.
+///
+/// Used via ``TokenEncodingConfiguration``:
+/// ```swift
+/// let encoder = JSONEncoder()
+/// encoder.tokenEncodingConfiguration = TokenEncodingConfiguration(
+///     tokenValue: TokenValueEncodingConfiguration(
+///         color: .hex,
+///         file: .path,
+///         measurement: .value(withUnit: true)
+///     )
+/// )
+/// ```
 public struct TokenValueEncodingConfiguration: Equatable, Sendable {
+    /// Default configuration with standard DTCG-compliant value formats.
     public static let `default` = Self()
 
+    /// Color value encoding configuration as ``ColorValueEncodingConfiguration``.
+    ///
+    /// Controls color output format (hex string, RGB object, etc.). When `nil`,
+    /// uses default format.
     public let colorEncodingConfiguration: ColorValueEncodingConfiguration?
+
+    /// File value encoding configuration as ``FileValueEncodingConfiguration``.
+    ///
+    /// Controls file output format (path, base64, URL). When `nil`, uses
+    /// default format.
     public let fileEncodingConfiguration: FileValueEncodingConfiguration?
+
+    /// Measurement encoding configuration as ``MeasurementValueEncodingConfiguration``.
+    ///
+    /// Controls dimension and duration output format (object, string with unit,
+    /// bare number). When `nil`, uses default format.
     public let measurementEncodingConfiguration: MeasurementValueEncodingConfiguration?
 
+    /// Creates a token value encoding configuration.
+    ///
+    /// - Parameters:
+    ///   - colorEncodingConfiguration: Color encoding configuration (optional)
+    ///   - fileEncodingConfiguration: File encoding configuration (optional)
+    ///   - measurementEncodingConfiguration: Measurement encoding configuration (optional)
     public init(
         color colorEncodingConfiguration: ColorValueEncodingConfiguration? =
             nil,

--- a/Sources/SnappDesignTokens/Values/StrokeStyleValue.swift
+++ b/Sources/SnappDesignTokens/Values/StrokeStyleValue.swift
@@ -6,28 +6,97 @@
 
 import Foundation
 
+/// Represents stroke style applied to lines or borders.
+///
+/// DTCG stroke style token supporting two formats: predefined line styles
+/// (solid, dashed, dotted, etc.) or custom dash patterns with line cap control.
+/// Follows CSS "line style" values with implementation-specific rendering.
+///
+/// Example:
+/// ```swift
+/// // Simple line style
+/// let solid: StrokeStyleValue = .line(.solid)
+///
+/// // Custom dash pattern
+/// let dashed = StrokeStyleValue.dash(.init(
+///     dashArray: [
+///         .value(.constant(.init(value: 0.5, unit: .rem))),
+///         .value(.constant(.init(value: 0.25, unit: .rem)))
+///     ],
+///     lineCap: .round
+/// ))
+/// ```
 public enum StrokeStyleValue: Codable, Equatable, Sendable, CompositeToken {
+    /// Predefined stroke line styles.
+    ///
+    /// DTCG-compliant line style values following CSS "line style" specification.
+    /// Exact visual rendering is implementation-specific.
     public enum LineStyle: String, Codable, Equatable, Sendable {
+        /// Solid continuous line.
         case solid
+
+        /// Dashed line pattern.
         case dashed
+
+        /// Dotted line pattern.
         case dotted
+
+        /// Double parallel lines.
         case double
+
+        /// Grooved 3D effect line.
         case groove
+
+        /// Ridged 3D effect line.
         case ridge
+
+        /// Outset 3D effect line.
         case outset
+
+        /// Inset 3D effect line.
         case inset
     }
 
+    /// Line cap style for dash pattern endpoints.
+    ///
+    /// Determines how the endpoints of dashed line segments are rendered.
     public enum LineCap: String, Codable, Equatable, Sendable {
+        /// Rounded cap extending beyond segment endpoint.
         case round
+
+        /// Flat cap flush with segment endpoint.
         case butt
+
+        /// Square cap extending beyond segment endpoint.
         case square
     }
 
+    /// Custom dash pattern with alternating dash and gap lengths.
+    ///
+    /// DTCG composite structure defining stroke dash pattern using dimension
+    /// array specifying alternating dash/gap segment lengths with line cap style.
+    ///
+    /// Example:
+    /// ```swift
+    /// let pattern = DashPattern(
+    ///     dashArray: [
+    ///         .value(.constant(.init(value: 0.5, unit: .rem))),  // dash length
+    ///         .value(.constant(.init(value: 0.25, unit: .rem)))  // gap length
+    ///     ],
+    ///     lineCap: .round
+    /// )
+    /// ```
     public struct DashPattern: Codable, Equatable, Sendable, CompositeToken {
+        /// Array of ``DimensionValue`` specifying alternating dash and gap lengths.
         public let dashArray: [CompositeTokenValue<DimensionValue>]
+
+        /// Line cap style applied to dash segment endpoints as ``LineCap``.
         public let lineCap: LineCap
 
+        /// Resolves token aliases in dash array dimension values.
+        ///
+        /// - Parameter root: Root ``Token`` for alias resolution
+        /// - Throws: ``TokenResolutionError`` if alias path is invalid or ``CompositeTokenValueAliasResolutionError/typeMismatch(path:)`` if referenced token is not a dimension
         public mutating func resolveAliases(root: Token) throws {
             self = try .init(
                 dashArray: dashArray.map {
@@ -38,9 +107,19 @@ public enum StrokeStyleValue: Codable, Equatable, Sendable, CompositeToken {
         }
     }
 
+    /// Predefined line style case with ``LineStyle`` value.
     case line(LineStyle)
+
+    /// Custom dash pattern case with ``DashPattern`` structure.
     case dash(DashPattern)
 
+    /// Decodes stroke style from either string line style or dash pattern object.
+    ///
+    /// Attempts to decode as ``LineStyle`` string first, falls back to
+    /// ``DashPattern`` object structure per DTCG specification.
+    ///
+    /// - Parameter decoder: The decoder to read data from
+    /// - Throws: Decoding error if neither format matches
     public init(from decoder: any Decoder) throws {
         do {
             self = .line(try LineStyle(from: decoder))
@@ -49,6 +128,10 @@ public enum StrokeStyleValue: Codable, Equatable, Sendable, CompositeToken {
         }
     }
 
+    /// Encodes stroke style as either string line style or dash pattern object.
+    ///
+    /// - Parameter encoder: The encoder to write data to
+    /// - Throws: Encoding error if value cannot be encoded
     public func encode(to encoder: any Encoder) throws {
         switch self {
         case .line(let lineStyle):
@@ -58,6 +141,13 @@ public enum StrokeStyleValue: Codable, Equatable, Sendable, CompositeToken {
         }
     }
 
+    /// Resolves token aliases within dash pattern if present.
+    ///
+    /// No-op for predefined line styles; resolves dimension value aliases
+    /// in ``DashPattern`` dash array.
+    ///
+    /// - Parameter root: Root ``Token`` for alias resolution
+    /// - Throws: ``TokenResolutionError`` if alias path is invalid or ``CompositeTokenValueAliasResolutionError/typeMismatch(path:)`` if referenced token is not a dimension
     public mutating func resolveAliases(root: Token) throws {
         guard case .dash(var pattern) = self else { return }
         try pattern.resolveAliases(root: root)


### PR DESCRIPTION
## Added DocC documentation to:
  - StrokeStyleValue.swift
  - MeasurementValueEncodingConfiguration.swift
  - TokenDecodingConfiguration.swift
  - TokenEncodingConfiguration.swift
  - TokenValueDecodingConfiguration.swift
  - TokenValueEncodingConfiguration.swift