### PR TITLE
Documentation: `Processors` folder

### DIFF
--- a/Sources/SnappDesignTokens/Processors/CombineProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/CombineProcessor.swift
@@ -4,13 +4,41 @@
 //  Created by Volodymyr Voiko on 09.04.2025.
 //
 
+/// Processor that chains multiple processors sequentially.
+///
+/// Executes processors in order, passing output of each processor as input
+/// to the next. Enables building complex processing pipelines from simple
+/// reusable components.
+///
+/// Example:
+/// ```swift
+/// let processor: TokenProcessor = .combine(
+///     .resolveAliases,
+///     .arithmeticalEvaluation,
+///     .dimensionValueConversion(targetUnit: .rem),
+///     .flatten(pathConversionStrategy: .dotSeparated)
+/// )
+/// let result = try await processor.process(token)
+/// ```
 public struct CombineProcessor: TokenProcessor {
+    /// Array of processors to execute sequentially.
     public let processors: [TokenProcessor]
 
+    /// Creates a combine processor.
+    ///
+    /// - Parameter processors: Array of processors to chain
     public init(processors: [TokenProcessor]) {
         self.processors = processors
     }
 
+    /// Processes token through all processors sequentially.
+    ///
+    /// Each processor receives the output of the previous processor. Returns
+    /// final transformed token after all processors complete.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Token tree after all processors have been applied
+    /// - Throws: Error from any processor in the chain
     public func process(_ token: Token) async throws -> Token {
         var transformedToken = token
         for processor in processors {
@@ -21,12 +49,20 @@ public struct CombineProcessor: TokenProcessor {
 }
 
 extension TokenProcessor where Self == CombineProcessor {
+    /// Creates a combine processor from variadic processor arguments.
+    ///
+    /// - Parameter processors: Processors to chain sequentially
+    /// - Returns: ``CombineProcessor`` executing processors in order
     public static func combine(_ processors: TokenProcessor...) -> Self {
         .init(processors: processors)
     }
 }
 
 extension TokenProcessor {
+    /// Chains this processor with another processor.
+    ///
+    /// - Parameter other: Processor to execute after this processor
+    /// - Returns: Combined processor executing both in sequence
     public func combine( _ other: TokenProcessor) -> TokenProcessor {
         .combine(self, other)
     }

--- a/Sources/SnappDesignTokens/Processors/DimensionValueConversionProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/DimensionValueConversionProcessor.swift
@@ -4,10 +4,32 @@
 //  Created by Volodymyr Voiko on 13.03.2025.
 //
 
+/// Processor that converts dimension values to a target unit.
+///
+/// Traverses token tree converting all dimension values (constants, expressions,
+/// typography dimensions) to specified target unit using ``DimensionValueConverter``.
+/// Handles dimension constants, expression elements, and typography font size/letter spacing.
+///
+/// Example:
+/// ```swift
+/// // Tokens with mixed units: { "spacing": "16px", "margin": "1rem" }
+///
+/// let processor: TokenProcessor = .dimensionValueConversion(targetUnit: .rem)
+/// let converted = try await processor.process(token)
+/// // Result: { "spacing": "1rem", "margin": "1rem" }
+/// ```
 public struct DimensionValueConversionProcessor: TokenProcessor {
+    /// Converter for unit conversion calculations as ``DimensionValueConverter``.
     public let converter: DimensionValueConverter
+
+    /// Target unit for all dimension values as ``DimensionUnit``.
     public let targetUnit: DimensionUnit
 
+    /// Creates a dimension value conversion processor.
+    ///
+    /// - Parameters:
+    ///   - converter: Converter implementation (default: `.default`)
+    ///   - targetUnit: Target dimension unit (default: `.default`)
     public init(
         converter: DimensionValueConverter = .default,
         targetUnit: DimensionUnit = .default
@@ -16,6 +38,14 @@ public struct DimensionValueConversionProcessor: TokenProcessor {
         self.targetUnit = targetUnit
     }
 
+    /// Converts all dimension values to target unit.
+    ///
+    /// Processes dimension constants, expression elements, and typography
+    /// dimensions (fontSize, letterSpacing). Non-dimension tokens pass through
+    /// unchanged.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Token tree with dimensions converted to target unit
     public func process(_ token: Token) async throws -> Token {
         token.map { element in
             switch element {
@@ -50,6 +80,12 @@ public struct DimensionValueConversionProcessor: TokenProcessor {
 
 extension TokenProcessor
 where Self == DimensionValueConversionProcessor {
+    /// Creates a dimension value conversion processor.
+    ///
+    /// - Parameters:
+    ///   - converter: Converter implementation (default: `.default`)
+    ///   - targetUnit: Target dimension unit
+    /// - Returns: Configured ``DimensionValueConversionProcessor``
     public static func dimensionValueConversion(
         using converter: DimensionValueConverter = .default,
         targetUnit: DimensionUnit

--- a/Sources/SnappDesignTokens/Processors/DimensionValueEvaluationProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/DimensionValueEvaluationProcessor.swift
@@ -6,13 +6,39 @@
 
 import Foundation
 
+/// Processor that evaluates dimension expressions to constant values.
+///
+/// Traverses token tree converting dimension expression tokens (e.g., `16 * 1.5`)
+/// to constant dimension values using pluggable ``DimensionValueEvaluator``
+/// implementations. Supports arithmetic and NSExpression-based evaluation.
+///
+/// Example:
+/// ```swift
+/// // Token with expression: { "spacing": "16px * 1.5" }
+///
+/// let processor: TokenProcessor = .arithmeticalEvaluation
+/// let evaluated = try await processor.process(token)
+/// // Result: { "spacing": "24px" }
+/// ```
 public struct DimensionValueEvaluationProcessor: TokenProcessor {
+    /// Evaluator for computing dimension expression results as ``DimensionValueEvaluator``.
     public let evaluator: DimensionValueEvaluator
 
+    /// Creates a dimension value evaluation processor.
+    ///
+    /// - Parameter evaluator: Evaluator implementation for expression computation
     public init(evaluator: DimensionValueEvaluator) {
         self.evaluator = evaluator
     }
 
+    /// Evaluates all dimension expressions in token tree.
+    ///
+    /// Replaces dimension expression tokens with constant dimension values.
+    /// Non-expression tokens pass through unchanged.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Token tree with expressions evaluated to constants
+    /// - Throws: Evaluation error if expression is invalid or cannot be computed
     public func process(_ token: Token) async throws -> Token {
         try token.map { element in
             guard
@@ -29,6 +55,10 @@ public struct DimensionValueEvaluationProcessor: TokenProcessor {
 
 extension TokenProcessor
 where Self == DimensionValueEvaluationProcessor {
+    /// Arithmetical expression evaluator with px base unit (basic arithmetic only).
+    ///
+    /// Uses ``ArithmeticalExpressionEvaluator`` supporting `+`, `-`, `*`, `/`
+    /// operators with parentheses.
     public static var arithmeticalEvaluation: Self {
         DimensionValueEvaluationProcessor(
             evaluator: ArithmeticalExpressionEvaluator(
@@ -38,6 +68,10 @@ where Self == DimensionValueEvaluationProcessor {
         )
     }
 
+    /// NSExpression-based evaluator with px base unit (full expression support).
+    ///
+    /// Uses ``NSExpressionDimensionEvaluator`` leveraging Foundation's
+    /// `NSExpression` for advanced mathematical operations.
     public static var expressionsEvaluation: Self {
         DimensionValueEvaluationProcessor(
             evaluator: NSExpressionDimensionEvaluator(

--- a/Sources/SnappDesignTokens/Processors/FileCachingProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/FileCachingProcessor.swift
@@ -8,13 +8,42 @@ import Foundation
 import OSLog
 import UniformTypeIdentifiers
 
+/// Processor that downloads and caches remote file token assets.
+///
+/// Downloads files referenced by file tokens to local cache using
+/// ``AssetsManager``. Replaces remote URLs with local file URLs. Handles
+/// images and fonts with type-specific caching. Logs errors for failed
+/// downloads while preserving original tokens.
+///
+/// Example:
+/// ```swift
+/// let manager = AssetsManager(themeName: "myTheme")
+/// let processor = FileCachingProcessor(assetsManager: manager)
+/// let cached = try await processor.process(token)
+/// // File tokens now reference local cached files
+/// ```
+///
+/// - Note: Non-file tokens pass through unchanged. Failed downloads are logged
+///   and original token is preserved.
 struct FileCachingProcessor: TokenProcessor {
+    /// Assets manager for downloading and caching files as ``AssetsManager``.
     let assetsManager: AssetsManager
 
+    /// Creates a file caching processor.
+    ///
+    /// - Parameter assetsManager: Assets manager instance for file operations
     init(assetsManager: AssetsManager) {
         self.assetsManager = assetsManager
     }
 
+    /// Downloads and caches file token assets.
+    ///
+    /// Extracts MIME type from file extension, downloads file to local cache,
+    /// and returns token with updated local URL. Non-file tokens and tokens
+    /// without valid MIME types pass through unchanged.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Token with file URLs replaced by local cached paths
     func process(_ token: Token) async throws -> Token {
         guard case let .value(.file(fileInfo)) = token else {
             return token

--- a/Sources/SnappDesignTokens/Processors/ResolveAliasesTokenProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/ResolveAliasesTokenProcessor.swift
@@ -7,9 +7,32 @@
 import Foundation
 import OSLog
 
+/// Processor that resolves all token aliases to their actual values.
+///
+/// Traverses the token tree replacing all alias references (using `{group.token}`
+/// syntax) with their resolved values. Handles nested aliases, composite token
+/// aliases, and dimension expression aliases. Detects circular references.
+///
+/// Example:
+/// ```swift
+/// // Token tree with aliases:
+/// // { "base": { "color": "#ff0000" }, "primary": "{base.color}" }
+///
+/// let processor: TokenProcessor = .resolveAliases
+/// let resolved = try await processor.process(token)
+/// // Result: { "base": { "color": "#ff0000" }, "primary": "#ff0000" }
+/// ```
+///
+/// - SeeAlso: ``Token/resolveAliases()`` for alias resolution implementation
 public struct ResolveAliasesTokenProcessor: TokenProcessor {
+    /// Creates a resolve aliases processor.
     public init() {}
 
+    /// Resolves all aliases in the token tree.
+    ///
+    /// - Parameter token: Token tree containing aliases to resolve
+    /// - Returns: Token tree with all aliases replaced by actual values
+    /// - Throws: ``TokenResolutionError`` if alias path is invalid or ``TokenResolutionError/circularReference`` if circular dependency detected
     public func process(_ token: Token) async throws -> Token {
         var resolved = token
         try resolved.resolveAliases()
@@ -18,6 +41,7 @@ public struct ResolveAliasesTokenProcessor: TokenProcessor {
 }
 
 extension TokenProcessor where Self == ResolveAliasesTokenProcessor {
+    /// Convenience accessor for resolve aliases processor.
     public static var resolveAliases: Self {
         ResolveAliasesTokenProcessor()
     }

--- a/Sources/SnappDesignTokens/Processors/SkipKeysProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/SkipKeysProcessor.swift
@@ -4,16 +4,38 @@
 //  Created by Volodymyr Voiko on 09.04.2025.
 //
 
-
 import Foundation
 
+/// Processor that removes specified keys from token groups.
+///
+/// Filters out unwanted top-level keys from token group dictionaries. Useful
+/// for excluding metadata, private tokens, or DTCG special properties before
+/// further processing.
+///
+/// Example:
+/// ```swift
+/// let processor: TokenProcessor = .skipKeys("$schema", "$metadata", "_internal")
+/// let processed = try await processor.process(token)
+/// // Removes $schema, $metadata, and _internal keys from root group
+/// ```
 public struct SkipKeysProcessor: TokenProcessor {
+    /// Set of keys to remove from token groups.
     public let skippedKeys: Set<String>
-    
+
+    /// Creates a skip keys processor.
+    ///
+    /// - Parameter skippedKeys: Set of key names to remove (default: empty set)
     public init(skippedKeys: Set<String> = []) {
         self.skippedKeys = skippedKeys
     }
-    
+
+    /// Removes specified keys from root token group.
+    ///
+    /// Only processes top-level keys in the root group. Returns token unchanged
+    /// if not a group token.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Token tree with specified keys removed from root group
     public func process(_ token: Token) async throws -> Token {
         guard case .group(var group) = token else {
             return token
@@ -26,10 +48,18 @@ public struct SkipKeysProcessor: TokenProcessor {
 }
 
 extension TokenProcessor where Self == SkipKeysProcessor {
+    /// Creates a skip keys processor with variadic key names.
+    ///
+    /// - Parameter keys: Key names to remove from token groups
+    /// - Returns: Configured ``SkipKeysProcessor``
     public static func skipKeys(_ keys: String...) -> Self {
         .init(skippedKeys: .init(keys))
     }
 
+    /// Creates a skip keys processor with array of key names.
+    ///
+    /// - Parameter keys: Key names to remove from token groups
+    /// - Returns: Configured ``SkipKeysProcessor``
     public static func skipKeys(_ keys: [String]) -> Self {
         .init(skippedKeys: .init(keys))
     }

--- a/Sources/SnappDesignTokens/Processors/TokenProcessor.swift
+++ b/Sources/SnappDesignTokens/Processors/TokenProcessor.swift
@@ -4,6 +4,35 @@
 //  Created by Volodymyr Voiko on 03.03.2025.
 //
 
+/// Protocol for transforming token trees.
+///
+/// Defines a pipeline-based architecture for processing design tokens. Processors
+/// can resolve aliases, flatten hierarchies, evaluate expressions, or perform
+/// custom transformations. Multiple processors can be combined sequentially.
+///
+/// Built-in processors:
+/// - ``ResolveAliasesTokenProcessor`` - Resolves all token aliases
+/// - ``FlattenProcessor`` - Flattens nested token groups
+/// - ``DimensionValueEvaluationProcessor`` - Evaluates dimension expressions
+/// - ``DimensionValueConversionProcessor`` - Converts dimension units
+/// - ``CombineProcessor`` - Chains multiple processors
+///
+/// Example:
+/// ```swift
+/// let processor: TokenProcessor = .combine(
+///     .resolveAliases,
+///     .flatten(pathConversionStrategy: .dotSeparated)
+/// )
+/// let processed = try await processor.process(token)
+/// ```
 public protocol TokenProcessor: Sendable {
+    /// Processes a token tree, returning a transformed result.
+    ///
+    /// Implementations should not mutate the input token. Return a new token
+    /// with transformations applied.
+    ///
+    /// - Parameter token: Token tree to process
+    /// - Returns: Transformed token tree
+    /// - Throws: Processing error if transformation fails
     func process(_ token: Token) async throws -> Token
 }


### PR DESCRIPTION
Added DocC documentation to:
  - TokenProcessor.swift
  - SkipKeysProcessor.swift
  - ResolveAliasesTokenProcessor.swift
  - FlattenProcessor.swift
  - FileCachingProcessor.swift
  - DimensionValueEvaluationProcessor.swift
  - DimensionValueConversionProcessor.swift
  - CombineProcessor.swift