### PR TITLE
Documentation: `Expressions` folder

### DIFF
--- a/Sources/SnappDesignTokens/Expressions/ArithmeticOperation.swift
+++ b/Sources/SnappDesignTokens/Expressions/ArithmeticOperation.swift
@@ -6,11 +6,39 @@
 
 import Foundation
 
+/// Arithmetic operators and parentheses for dimension expressions.
+///
+/// Represents mathematical operations and grouping symbols used in DTCG
+/// dimension expression evaluation.
+///
+/// Example:
+/// ```swift
+/// let expr = [
+///     .value(.init(value: 16, unit: .px)),
+///     .operation(.multiply),
+///     .operation(.leftParen),
+///     .value(.init(value: 1.5, unit: .px)),
+///     .operation(.add),
+///     .value(.init(value: 2, unit: .px)),
+///     .operation(.rightParen)
+/// ]  // 16 * (1.5 + 2) = 56
+/// ```
 public enum ArithmeticOperation: String, Decodable, CaseIterable, Equatable, Sendable {
+    /// Addition operator (`+`).
     case add = "+"
+
+    /// Subtraction operator (`-`).
     case subtract = "-"
+
+    /// Multiplication operator (`*`).
     case multiply = "*"
+
+    /// Division operator (`/`).
     case divide = "/"
+
+    /// Left parenthesis for grouping (`(`).
     case leftParen = "("
+
+    /// Right parenthesis for grouping (`)`).
     case rightParen = ")"
 }

--- a/Sources/SnappDesignTokens/Expressions/DimensionExpression.swift
+++ b/Sources/SnappDesignTokens/Expressions/DimensionExpression.swift
@@ -6,19 +6,46 @@
 
 import Foundation
 
+/// Mathematical expression for dimension values.
+///
+/// DTCG dimension token value representing mathematical formula as sequence
+/// of elements (values, operators, parentheses, aliases). Encoded as string,
+/// decoded into structured element array for evaluation.
+///
+/// Example:
+/// ```swift
+/// // JSON: "16px * 1.5"
+/// // Decoded to:
+/// let expr = DimensionExpression(elements: [
+///     .value(.init(value: 16, unit: .px)),
+///     .operation(.multiply),
+///     .value(.init(value: 1.5, unit: .px))
+/// ])
+/// ```
 public struct DimensionExpression: Equatable, Sendable {
     private enum Constant {
         static let defaultRemBaseValue: CGFloat = 16
     }
 
+    /// Array of expression elements (values, operations, aliases).
     public var elements: [DimensionExpressionElement]
 
+    /// Creates a dimension expression.
+    ///
+    /// - Parameter elements: Expression elements in evaluation order
     public init(elements: [DimensionExpressionElement]) {
         self.elements = elements
-    }    
+    }
 }
 
 extension DimensionExpression: Codable {
+    /// Decodes dimension expression from string.
+    ///
+    /// Parses mathematical formula string splitting into elements by operators
+    /// and parentheses. Recognizes dimension values, aliases, and operations.
+    ///
+    /// - Parameter decoder: Decoder to read from
+    /// - Throws: ``DimensionExpressionParsingError`` or ``DecodingError`` if parsing fails
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let rawString = try container.decode(String.self)
@@ -40,6 +67,13 @@ extension DimensionExpression: Codable {
         }
     }
 
+    /// Encodes dimension expression to string.
+    ///
+    /// Converts element array back to mathematical formula string by joining
+    /// raw values.
+    ///
+    /// - Parameter encoder: Encoder to write to
+    /// - Throws: Encoding error if serialization fails
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         let stringValue = elements.map(\.rawValue).joined()

--- a/Sources/SnappDesignTokens/Expressions/DimensionExpressionElement.swift
+++ b/Sources/SnappDesignTokens/Expressions/DimensionExpressionElement.swift
@@ -6,11 +6,30 @@
 
 import Foundation
 
+/// Element of a dimension expression.
+///
+/// Represents individual components in mathematical dimension expressions:
+/// operations, dimension values, or token alias references.
+///
+/// Example:
+/// ```swift
+/// let elements: [DimensionExpressionElement] = [
+///     .value(16, .px),           // Dimension value
+///     .operation(.multiply),     // Operator
+///     .alias(TokenPath("spacing.base"))  // Token reference
+/// ]
+/// ```
 public enum DimensionExpressionElement: Equatable, Sendable, RawRepresentable {
+    /// Arithmetic operation or parenthesis.
     case operation(ArithmeticOperation)
+
+    /// Token alias reference.
     case alias(TokenPath)
+
+    /// Dimension constant value.
     case value(DimensionConstant)
 
+    /// String representation of element.
     public var rawValue: String {
         switch self {
         case .operation(let operation):
@@ -22,6 +41,12 @@ public enum DimensionExpressionElement: Equatable, Sendable, RawRepresentable {
         }
     }
 
+    /// Creates element by parsing string value.
+    ///
+    /// Attempts to parse as operation, alias, or dimension constant.
+    ///
+    /// - Parameter stringValue: String to parse
+    /// - Throws: ``DimensionExpressionElementParseError`` if format is invalid
     public init(from stringValue: String) throws {
         if let operation = ArithmeticOperation(rawValue: stringValue) {
             self = .operation(operation)
@@ -34,18 +59,36 @@ public enum DimensionExpressionElement: Equatable, Sendable, RawRepresentable {
         }
     }
 
+    /// Creates element from raw string value.
+    ///
+    /// Failable initializer returning `nil` for invalid formats.
+    ///
+    /// - Parameter rawValue: String to parse
     public init?(rawValue: String) {
         try? self.init(from: rawValue)
     }
 }
 
 extension DimensionExpressionElement {
+    /// Creates dimension value element.
+    ///
+    /// - Parameters:
+    ///   - value: Numeric value
+    ///   - unit: Dimension unit (default: `.px`)
+    /// - Returns: Value element with dimension constant
     public static func value(_ value: Double, _ unit: DimensionUnit = .px) -> Self {
         .value(DimensionConstant(value: value, unit: unit))
     }
 
+    /// Addition operation element.
     public static let add: Self = .operation(.add)
+
+    /// Multiplication operation element.
     public static let multiply: Self = .operation(.multiply)
+
+    /// Division operation element.
     public static let divide: Self = .operation(.divide)
+
+    /// Subtraction operation element.
     public static let subtract: Self = .operation(.subtract)
 }

--- a/Sources/SnappDesignTokens/Expressions/DimensionExpressionElementParseError.swift
+++ b/Sources/SnappDesignTokens/Expressions/DimensionExpressionElementParseError.swift
@@ -6,9 +6,17 @@
 
 import Foundation
 
+/// Errors that occur when parsing dimension expression elements.
+///
+/// Thrown by ``DimensionExpressionElement`` initializers when string cannot
+/// be parsed as operation, alias, or dimension constant.
 public enum DimensionExpressionElementParseError: String, Error, LocalizedError {
+    /// String format is not a valid expression element.
+    ///
+    /// String does not match operation symbol, alias syntax, or dimension format.
     case invalidFormat
 
+    /// Human-readable error description.
     public var errorDescription: String? {
         switch self {
         case .invalidFormat:
@@ -18,6 +26,12 @@ public enum DimensionExpressionElementParseError: String, Error, LocalizedError 
 }
 
 extension DimensionExpressionElementParseError: Equatable {
+    /// Compares errors for equality based on localized descriptions.
+    ///
+    /// - Parameters:
+    ///   - lhs: Left-hand side error
+    ///   - rhs: Right-hand side error
+    /// - Returns: `true` if errors have identical descriptions
     public static func == (
         lhs: DimensionExpressionElementParseError,
         rhs: DimensionExpressionElementParseError

--- a/Sources/SnappDesignTokens/Expressions/DimensionExpressionParsingError.swift
+++ b/Sources/SnappDesignTokens/Expressions/DimensionExpressionParsingError.swift
@@ -6,10 +6,23 @@
 
 import Foundation
 
+/// Errors that occur when parsing dimension expression strings.
+///
+/// Thrown by ``DimensionExpression`` decoder when mathematical formula string
+/// cannot be split into valid expression elements.
 public enum DimensionExpressionParsingError: Error, LocalizedError, Equatable {
+    /// Expression string has invalid overall format.
+    ///
+    /// String is empty or cannot be tokenized into elements.
     case invalidFormat
+
+    /// Specific element in expression is invalid.
+    ///
+    /// Element substring does not match any valid pattern (operation, alias,
+    /// or dimension constant).
     case invalidElement(String)
 
+    /// Human-readable error description.
     public var errorDescription: String? {
         switch self {
         case .invalidFormat:
@@ -19,6 +32,12 @@ public enum DimensionExpressionParsingError: Error, LocalizedError, Equatable {
         }
     }
 
+    /// Compares errors for equality based on localized descriptions.
+    ///
+    /// - Parameters:
+    ///   - lhs: Left-hand side error
+    ///   - rhs: Right-hand side error
+    /// - Returns: `true` if errors have identical descriptions
     public static func == (
         lhs: DimensionExpressionParsingError,
         rhs: DimensionExpressionParsingError


### PR DESCRIPTION
Added DocC documentation to:
  - `ArithmeticOperation.swift`
  - `DimensionExpression.swift`
  - `DimensionExpressionElement.swift`
  - `DimensionExpressionElementParseError.swift`
  - `DimensionExpressionParsingError.swift`