### PR TITLE
File header template configuration

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -6,7 +6,7 @@
 	<string>
 //  ___FILENAME___
 //
-//  Created by ___FULLUSERNAME___ on___DATE___.
+//  Created by ___FULLUSERNAME___ on ___DATE___.
 //</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Added `IDETemplateMacros.plist` to configure file headers for new files created in Xcode.

Location: `.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist`

### Template format:
```swift
//
//  FileName.swift
//
//  Created by Author Name on MM/DD/YY.
//
```
### Examples:
```swift
//
//  TokenProcessor.swift
//
//  Created by John Smith on 10/1/25.
//
```
```swift
//
//  ColorValue+Helpers.swift
//
//  Created by Jane Doe on 12/15/25.
//
```
This ensures consistent file headers across the project. The template will be automatically used by Xcode when creating new Swift files.