### PR TITLE
Simplier pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,68 +1,8 @@
-# Pull Request
+## What
+<!-- What was changed -->
 
-## Summary
-<!-- Provide a brief description of the changes in this pull request -->
+## Why
+<!-- Why this change was needed -->
 
-## Type of Change
-<!-- Mark the type of change this PR represents -->
-
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] 📚 Documentation update
-- [ ] 🔧 Code refactoring (no functional changes)
-- [ ] ⚡ Performance improvement
-- [ ] 🧪 Test addition or improvement
-- [ ] 🔨 Build/CI changes
-
-## Changes Made
-<!-- Describe the specific changes made in this PR -->
-
--
--
--
-
-## Related Issues
-<!-- Link any related issues using GitHub keywords (e.g., "Fixes #123", "Closes #456") -->
-
-Fixes #
-Relates to #
-
-## Testing
-<!-- Describe the testing performed for these changes -->
-
-### Test Environment
-- [ ] Swift version:
-- [ ] Platform tested: iOS/macOS/watchOS/tvOS
-- [ ] Xcode version:
-
-### Tests Performed
-- [ ] Unit tests pass
-- [ ] Integration tests pass
-- [ ] Manual testing completed
-- [ ] Performance testing (if applicable)
-
-### Test Coverage
-<!-- Describe what was tested and any areas that need additional testing -->
-
-## Screenshots/Examples
-<!-- If applicable, add screenshots or code examples to help explain your changes -->
-
-```swift
-// Example usage or before/after code snippets
-```
-
-## Checklist
-<!-- Review the following items before submitting your PR -->
-
-- [ ] My code follows the project's coding standards
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
-
-## Additional Notes
-<!-- Add any additional notes, considerations, or context for reviewers -->
+## Changes
+<!-- List affected files/modules -->


### PR DESCRIPTION
## What
Simplified GitHub pull request template

## Why
Previous template was too verbose with unnecessary sections. We need only essential information: what changed, why, and where.

## Changes
- `.github/pull_request_template.md`