### PR TITLE
Feature/tokens documentation

### DIFF
--- a/Sources/SnappDesignTokens/Configurations/TokenDecodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenDecodingConfiguration.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Controls token parsing behavior including file value decoding, type inheritance
 /// from parent groups, and custom type mappings for non-standard token types.
 ///
-/// Set on ``JSONDecoder`` via `tokenDecodingConfiguration` property:
+/// Set on `JSONDecoder` via `tokenDecodingConfiguration` property:
 /// ```swift
 /// let decoder = JSONDecoder()
 /// decoder.tokenDecodingConfiguration = TokenDecodingConfiguration(

--- a/Sources/SnappDesignTokens/Configurations/TokenEncodingConfiguration.swift
+++ b/Sources/SnappDesignTokens/Configurations/TokenEncodingConfiguration.swift
@@ -12,7 +12,7 @@ import Foundation
 /// files, and measurements. Enables customization of output format while
 /// maintaining DTCG compliance or generating compact representations.
 ///
-/// Set on ``JSONEncoder`` via `tokenEncodingConfiguration` property:
+/// Set on `JSONEncoder` via `tokenEncodingConfiguration` property:
 /// ```swift
 /// let encoder = JSONEncoder()
 /// encoder.tokenEncodingConfiguration = TokenEncodingConfiguration(

--- a/Sources/SnappDesignTokens/Expressions/DimensionExpression.swift
+++ b/Sources/SnappDesignTokens/Expressions/DimensionExpression.swift
@@ -45,7 +45,7 @@ extension DimensionExpression: Codable {
     /// and parentheses. Recognizes dimension values, aliases, and operations.
     ///
     /// - Parameter decoder: Decoder to read from
-    /// - Throws: ``DimensionExpressionParsingError`` or ``DecodingError`` if parsing fails
+    /// - Throws: ``DimensionExpressionParsingError`` or `DecodingError` if parsing fails
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let rawString = try container.decode(String.self)

--- a/Sources/SnappDesignTokens/Expressions/ValueEvaluator/ArithmeticalExpressionEvaluator.swift
+++ b/Sources/SnappDesignTokens/Expressions/ValueEvaluator/ArithmeticalExpressionEvaluator.swift
@@ -6,12 +6,22 @@
 
 import Foundation
 
-/// A struct that evaluates mathematical expressions provided as strings.
-/// Conforms to `DimensionValueEvaluator` protocol to provide numeric evaluation capabilities.
-struct ArithmeticalExpressionEvaluator: DimensionValueEvaluator {
+/// Evaluates dimension formulas using custom arithmetic parser.
+///
+/// Alternative to NSExpression-based evaluation. Converts dimension expressions
+/// to formulas in base unit, then evaluates using ``ArithmeticalExpressionManager``.
+public struct ArithmeticalExpressionEvaluator: DimensionValueEvaluator {
+    /// Base unit for formula evaluation.
     let baseUnit: DimensionUnit
+
+    /// Converter for dimension unit transformations.
     let converter: DimensionValueConverter
 
+    /// Creates an arithmetic expression evaluator with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - baseUnit: Base unit for evaluation, defaults to `.px`
+    ///   - converter: Unit converter, defaults to `.default`
     init(
         baseUnit: DimensionUnit = .px,
         converter: DimensionValueConverter = .default
@@ -20,7 +30,15 @@ struct ArithmeticalExpressionEvaluator: DimensionValueEvaluator {
         self.converter = converter
     }
 
-    func evaluate(_ expression: DimensionExpression) throws -> DimensionConstant {
+    /// Evaluates a dimension expression to a constant value.
+    ///
+    /// Converts expression to formula in base unit, then evaluates using arithmetic parser.
+    /// Result is returned in the configured base unit.
+    ///
+    /// - Parameter expression: Dimension expression to evaluate
+    /// - Returns: Evaluated dimension constant in base unit
+    /// - Throws: Error if formula conversion or evaluation fails
+    public func evaluate(_ expression: DimensionExpression) throws -> DimensionConstant {
         let formula = try expression.formula(converter: converter, baseUnit: baseUnit)
         let manager = ArithmeticalExpressionManager<Double>(formula: formula)
         let evaluatedValue = try manager.evaluate()

--- a/Sources/SnappDesignTokens/Expressions/ValueEvaluator/DefaultDimensionFormulaSyntax.swift
+++ b/Sources/SnappDesignTokens/Expressions/ValueEvaluator/DefaultDimensionFormulaSyntax.swift
@@ -6,16 +6,29 @@
 
 import Foundation
 
-open class DefaultDimensionFormulaSyntax: DimensionFormulaSyntax {
+/// Default implementation of dimension formula syntax validation.
+///
+/// Validates mathematical formulas used in dimension token calculations,
+/// ensuring they contain only allowed characters and operations.
+public class DefaultDimensionFormulaSyntax: DimensionFormulaSyntax {
+    /// The formula string to validate and evaluate.
     let formula: String
 
-    init(formula: String) {
+    /// Creates a new formula syntax validator.
+    ///
+    /// - Parameter formula: Mathematical formula string
+    public init(formula: String) {
         self.formula = formula
     }
 
-    /// Validates the formula syntax using a recursive descent parser approach
-    /// - Throws: DimensionValueEvaluationError if the formula is invalid
-    func isValidFormat() throws(DimensionValueEvaluationError) {
+    /// Validates the formula syntax using a recursive descent parser approach.
+    ///
+    /// Checks for empty formulas, length limits (max 1000 characters), and ensures
+    /// only allowed characters (alphanumerics, arithmetic operators, parentheses, and periods)
+    /// are present.
+    ///
+    /// - Throws: ``DimensionValueEvaluationError`` if the formula is empty, too long, or contains invalid characters
+    public func isValidFormat() throws(DimensionValueEvaluationError) {
         // Check for empty formula
         if formula.isEmpty {
             throw .emptyFormula

--- a/Sources/SnappDesignTokens/Expressions/ValueEvaluator/NSExpression/NSExpressionDimensionEvaluator.swift
+++ b/Sources/SnappDesignTokens/Expressions/ValueEvaluator/NSExpression/NSExpressionDimensionEvaluator.swift
@@ -6,15 +6,31 @@
 
 import Foundation
 
-typealias NSExpressionDimensionEvaluator = DefaultNSExpressionDimensionEvaluator<RegularExpression>
+/// Type alias for the default NSExpression-based dimension evaluator.
+public typealias NSExpressionDimensionEvaluator = DefaultNSExpressionDimensionEvaluator<RegularExpression>
 
-/// A dimension value evaluator that uses NSExpression to calculate numeric values from dimension formulas
-struct DefaultNSExpressionDimensionEvaluator<T: RegularExpressionProtocol>: DimensionValueEvaluator {
+/// Evaluates dimension formulas using Foundation's NSExpression.
+///
+/// Calculates numeric values from mathematical expressions in dimension tokens.
+/// Converts all dimension values to a base unit before evaluation, then evaluates
+/// the formula using NSExpression.
+public struct DefaultNSExpressionDimensionEvaluator<T: RegularExpressionProtocol>: DimensionValueEvaluator {
+    /// Base unit for formula evaluation.
     let baseUnit: DimensionUnit
+
+    /// Converter for dimension unit transformations.
     let converter: DimensionValueConverter
+
+    /// Regular expression validator for formula syntax.
     var regularExpression: T
 
-    init(
+    /// Creates a dimension evaluator with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - baseUnit: Base unit for evaluation, defaults to `.px`
+    ///   - converter: Unit converter, defaults to `.default`
+    ///   - regularExpression: Formula validator, defaults to `RegularExpression()`
+    public init(
         baseUnit: DimensionUnit = .px,
         converter: DimensionValueConverter = .default,
         regularExpression: T = RegularExpression()
@@ -24,7 +40,15 @@ struct DefaultNSExpressionDimensionEvaluator<T: RegularExpressionProtocol>: Dime
         self.regularExpression = regularExpression
     }
 
-    func evaluate(
+    /// Evaluates a dimension expression to a constant value.
+    ///
+    /// Converts expression to formula in base unit, validates syntax, and evaluates
+    /// using NSExpression. Result is always returned in pixels.
+    ///
+    /// - Parameter expression: Dimension expression to evaluate
+    /// - Returns: Evaluated dimension constant in pixels
+    /// - Throws: ``DimensionValueEvaluationError`` if formula is invalid or evaluation fails
+    public func evaluate(
         _ expression: DimensionExpression
     ) throws -> DimensionConstant {
         let formula = try expression.formula(

--- a/Sources/SnappDesignTokens/Expressions/ValueEvaluator/NSExpression/RegularExpressionProtocol.swift
+++ b/Sources/SnappDesignTokens/Expressions/ValueEvaluator/NSExpression/RegularExpressionProtocol.swift
@@ -6,12 +6,31 @@
 
 import Foundation
 
-protocol RegularExpressionProtocol: Sendable {
+/// Protocol for creating regular expression instances.
+///
+/// Abstracts regular expression creation to enable dependency injection and testing.
+public protocol RegularExpressionProtocol: Sendable {
+    /// Creates a regular expression from a pattern string.
+    ///
+    /// - Parameter pattern: Regular expression pattern
+    /// - Returns: Compiled regular expression
+    /// - Throws: Error if pattern is invalid
     func expression(pattern: String) throws -> NSRegularExpression
 }
 
-struct RegularExpression: RegularExpressionProtocol {
-    func expression(pattern: String) throws -> NSRegularExpression {
+/// Default implementation using Foundation's NSRegularExpression.
+public struct RegularExpression: RegularExpressionProtocol {
+    /// Creates a regular expression provider.
+    public init() {
+
+    }
+
+    /// Creates a regular expression from a pattern string.
+    ///
+    /// - Parameter pattern: Regular expression pattern
+    /// - Returns: Compiled NSRegularExpression
+    /// - Throws: Error if pattern syntax is invalid
+    public func expression(pattern: String) throws -> NSRegularExpression {
         try NSRegularExpression(pattern: pattern)
     }
 }

--- a/Sources/SnappDesignTokens/Extensions/ColorValue+HEX.swift
+++ b/Sources/SnappDesignTokens/Extensions/ColorValue+HEX.swift
@@ -97,7 +97,7 @@ extension ColorValue {
     /// ```
     ///
     /// - Parameters:
-    ///   - format: Alpha channel placement (default: ``.rgba``)
+    ///   - format: Alpha channel placement (default: ``ColorHexFormat/rgba``)
     ///   - skipFullOpacityAlpha: Omit alpha when fully opaque (default: `false`)
     /// - Returns: Hex color string
     /// - Throws: ``ColorValueHexEncodingError`` if color space is not sRGB or components contain "none"

--- a/Sources/SnappDesignTokens/Managers/ArithmeticalExpressionManager.swift
+++ b/Sources/SnappDesignTokens/Managers/ArithmeticalExpressionManager.swift
@@ -6,21 +6,37 @@
 
 import Foundation
 
-protocol Numeric {
+/// Protocol for numeric types supporting arithmetic operations.
+///
+/// Enables generic mathematical expression evaluation across different numeric types.
+public protocol Numeric {
+    /// Adds two values.
     static func + (lhs: Self, rhs: Self) -> Self
+
+    /// Subtracts right value from left value.
     static func - (lhs: Self, rhs: Self) -> Self
+
+    /// Multiplies two values.
     static func * (lhs: Self, rhs: Self) -> Self
+
+    /// Divides left value by right value.
     static func / (lhs: Self, rhs: Self) -> Self
+
+    /// Checks equality of two values.
     static func == (lhs: Self, rhs: Self) -> Bool
+
+    /// Creates a value from a Double.
     init(_ value: Double)
 }
 
-// Extend Double to conform to our Numeric protocol
 extension Double: Numeric {}
 
-// Generic math expression manager that can work with Double by default
-// and can be extended to support other numeric types
-final class ArithmeticalExpressionManager<T: Numeric> {
+/// Evaluates mathematical expressions using recursive descent parsing.
+///
+/// Parses and evaluates arithmetic formulas with support for addition, subtraction,
+/// multiplication, division, parentheses, and unary operators. Includes protections
+/// against stack overflow and division by zero.
+final public class ArithmeticalExpressionManager<T: Numeric> {
     private var formula: String
     private var position: Int = 0
     private var currentChar: Character?
@@ -66,8 +82,14 @@ final class ArithmeticalExpressionManager<T: Numeric> {
         recursionDepth -= 1
     }
 
-    // Parses the formula and returns the result
-    func evaluate() throws(DimensionValueEvaluationError) -> T {
+    /// Evaluates the formula and returns the result.
+    ///
+    /// Validates syntax using ``DefaultDimensionFormulaSyntax``, then parses and evaluates
+    /// the expression using recursive descent parsing.
+    ///
+    /// - Returns: Evaluated numeric result
+    /// - Throws: ``DimensionValueEvaluationError`` if syntax is invalid, recursion limit exceeded, or division by zero occurs
+    public func evaluate() throws(DimensionValueEvaluationError) -> T {
         let syntaxChecker = DefaultDimensionFormulaSyntax(formula: formula)
         try syntaxChecker.isValidFormat()
 

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/DesignTokens.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/DesignTokens.md
@@ -1,0 +1,44 @@
+# DesignTokens
+
+Parse and work with Design Tokens Community Group (DTCG) format files in Swift.
+
+## Overview
+
+SnappDesignTokens implements the DTCG specification for design tokens, enabling type-safe parsing and manipulation of design token files in Swift applications.
+
+Design tokens are name/value pairs that store design decisions (colors, spacing, typography, etc.) in a platform-agnostic format. This library reads DTCG-compliant JSON files and converts them into Swift data structures.
+
+### Supported Token Types
+
+The library supports all DTCG token types, organized into primitive and composite categories:
+
+#### Primitive Types
+
+Primitive tokens have singular values:
+
+- ``ColorValue`` - Colors across different color spaces (sRGB, Display P3, HSL, Lab, etc.)
+- ``DimensionValue`` - Measurements with units (px, rem, em, etc.)
+- ``FontFamilyValue`` - Font family names with optional fallbacks
+- ``FontWeightValue`` - Font weights (numeric or named aliases)
+- ``DurationValue`` - Time durations for animations (seconds, milliseconds)
+- ``CubicBezierValue`` - Animation timing curves
+- ``NumberValue`` - Unitless numeric values
+
+#### Composite Types
+
+Composite tokens combine multiple sub-values in pre-defined structures:
+
+- ``BorderValue`` - Border styling with color, width, and stroke style
+- ``ShadowValue`` - Drop and inner shadows with color, offsets, and blur
+- ``GradientValue`` - Color gradients with multiple stops
+- ``TransitionValue`` - Animation transitions with duration, delay, and timing
+- ``TypographyValue`` - Complete typographic styles
+- ``StrokeStyleValue`` - Stroke patterns for borders and outlines
+
+### Key Features
+
+- **Type-safe parsing**: Converts JSON to strongly-typed Swift structures
+- **Token aliases**: Supports `{group.token}` reference syntax
+- **Alias resolution**: Resolves token references to actual values
+- **Comprehensive validation**: Type checking per DTCG specification
+- **Extensions support**: Handles `$extensions` for custom metadata

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/SnappDesignTokens.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/SnappDesignTokens.md
@@ -10,16 +10,6 @@ Framework for parsing and processing `DTCG` tokens.
 
 A Swift library for parsing and processing [DTCG-compliant](https://www.designtokens.org/tr/third-editors-draft/format/) design tokens into type-safe Swift structures.
 
+### Resources
+
 [Clone on GitHub](https://github.com/Snapp-Mobile/SnappDesignTokens)
-
-### Features
-
-- **DTCG Compliance:** Full specification support
-- **Token Types:** Color, Dimension, FontFamily, FontWeight, Duration, CubicBezier, Number, StrokeStyle, Border, Transition, Shadow, Gradient, Typography
-- **Alias Resolution:** `{group.token}` references
-- **Expression Evaluation:** Arithmetic operations in dimension values
-- **Unit Conversion:** px ↔ rem
-- **Processing Pipeline:** Composable token processors
-- **Asset Caching:** Built-in file caching
-- **Zero Dependencies:** Pure Swift implementation
-- **Cross-Platform:** iOS, macOS, tvOS, watchOS, visionOS

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Border.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Border.md
@@ -1,0 +1,69 @@
+# ``BorderValue``
+
+## Examples
+
+### Direct values
+
+```swift
+let border = BorderValue(
+    color: .value(.red),
+    width: .value(.constant(.init(value: 3, unit: .px))),
+    style: .value(.line(.solid))
+)
+```
+
+### With token aliases
+
+```swift
+let focusRing = BorderValue(
+    color: .alias("{color.focusring}"),
+    width: .value(.constant(.init(value: 1, unit: .px))),
+    style: .value(.dashed(/* ... */))
+)
+```
+
+### JSON format
+
+```json
+"border": {
+    "heavy": {
+      "$type": "border",
+      "$value": {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0.218, 0.218, 0.218]
+          }
+        },
+        "width": {
+          "value": 3,
+          "unit": "px"
+        },
+        "style": "solid"
+      }
+    },
+    "focusring": {
+      "$type": "border",
+      "$value": {
+        "color": "{color.focusring}",
+        "width": {
+          "value": 1,
+          "unit": "px"
+        },
+        "style": {
+          "dashArray": [
+            { "value": 0.5, "unit": "rem" },
+            { "value": 0.25, "unit": "rem" }
+          ],
+          "lineCap": "round"
+        }
+      }
+    }
+  }
+}
+```
+
+## References
+
+[Border composite token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#border)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Color.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Color.md
@@ -1,0 +1,58 @@
+# ``ColorValue``
+
+## Examples
+
+### Hex string format
+
+```swift
+// Decodes from: {"$value": "#FF0000", "$type": "color"}
+let red = try ColorValue(hex: "#FF0000")
+```
+
+### Structured format
+
+```swift
+// HSL with "none" component
+let hslWhite = ColorValue(
+    colorSpace: .hsl,
+    components: [.none, .value(0), .value(100)],
+    alpha: 1,
+    hex: "#ffffff"
+)
+
+// Lab color space
+let labMagenta = ColorValue(
+    colorSpace: .lab,
+    components: [.value(60.17), .value(93.54), .value(-60.5)],
+    hex: "#ff00ff"
+)
+```
+
+### JSON format
+
+```json
+{
+  "Hot pink": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [1, 0, 1],
+      "alpha": 1,
+      "hex": "#ff00ff"
+    }
+  },
+  "Translucent shadow": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "srgb",
+      "components": [0, 0, 0],
+      "alpha": 0.5,
+      "hex": "#000000"
+    }
+  }
+}
+```
+
+## References
+
+[Color token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#color)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Cubic Bezier.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Cubic Bezier.md
@@ -1,0 +1,32 @@
+# ``CubicBezierValue``
+
+## Examples
+
+### Direct values
+
+```swift
+// Decodes from: {"$value": [0.5, 0, 1, 1], "$type": "cubicBezier"}
+let accelerate = CubicBezierValue(x1: 0.5, y1: 0, x2: 1, y2: 1)
+
+// Decodes from: {"$value": [0, 0, 0.5, 1], "$type": "cubicBezier"}
+let decelerate = CubicBezierValue(x1: 0, y1: 0, x2: 0.5, y2: 1)
+```
+
+### JSON format
+
+```json
+{
+  "Accelerate": {
+    "$value": [0.5, 0, 1, 1],
+    "$type": "cubicBezier"
+  },
+  "Decelerate": {
+    "$value": [0, 0, 0.5, 1],
+    "$type": "cubicBezier"
+  }
+}
+```
+
+## References
+
+[Cubic Bézie token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#cubic-bezier)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Duration.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Duration.md
@@ -1,0 +1,38 @@
+# ``DurationValue``
+
+## Examples
+
+### Direct values
+
+```swift
+// Decodes from: {"$value": {"value": 100, "unit": "ms"}, "$type": "duration"}
+let quick = DurationValue(value: 100, unit: .millisecond)
+
+// Decodes from: {"$value": {"value": 1.5, "unit": "s"}, "$type": "duration"}
+let long = DurationValue(value: 1.5, unit: .second)
+```
+
+### JSON format
+
+```json
+{
+  "duration-quick": {
+    "$type": "duration",
+    "$value": {
+      "value": 100,
+      "unit": "ms"
+    }
+  },
+  "duration-long": {
+    "$type": "duration",
+    "$value": {
+      "value": 1.5,
+      "unit": "s"
+    }
+  }
+}
+```
+
+## References
+
+[Duration token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#duration)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Font family.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Font family.md
@@ -1,0 +1,32 @@
+# ``FontFamilyValue``
+
+## Examples
+
+### Direct values
+
+```swift
+// Decodes from: {"$value": "Comic Sans MS", "$type": "fontFamily"}
+let primary: FontFamilyValue = "Comic Sans MS"
+
+// Decodes from: {"$value": ["Helvetica", "Arial", "sans-serif"], "$type": "fontFamily"}
+let body = FontFamilyValue("Helvetica", "Arial", "sans-serif")
+```
+
+### JSON format
+
+```json
+{
+  "Primary font": {
+    "$value": "Comic Sans MS",
+    "$type": "fontFamily"
+  },
+  "Body font": {
+    "$value": ["Helvetica", "Arial", "sans-serif"],
+    "$type": "fontFamily"
+  }
+}
+```
+
+## References
+
+[Font family token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#font-family)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Font weight.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Font weight.md
@@ -1,0 +1,32 @@
+# ``FontWeightValue``
+
+## Examples
+
+### Direct values
+
+```swift
+// Decodes from: {"$value": 350, "$type": "fontWeight"}
+let custom = FontWeightValue(rawValue: 350)!
+
+// Decodes from: {"$value": "extra-bold", "$type": "fontWeight"}
+let thick = FontWeightValue(alias: .extraBold)
+```
+
+### JSON format
+
+```json
+{
+  "font-weight-default": {
+    "$value": 350,
+    "$type": "fontWeight"
+  },
+  "font-weight-thick": {
+    "$value": "extra-bold",
+    "$type": "fontWeight"
+  }
+}
+```
+
+## References
+
+[Font weight token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#font-weight)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Gradient.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Gradient.md
@@ -1,0 +1,96 @@
+# ``GradientColor``
+
+## Examples
+
+### Direct values
+
+```swift
+// Complete gradient with stops
+let blueToRed: GradientValue = [
+    GradientColor(
+        color: .value(ColorValue(colorSpace: .srgb, components: [.value(0), .value(0), .value(1)])),
+        position: .value(0)
+    ),
+    GradientColor(
+        color: .value(ColorValue(colorSpace: .srgb, components: [.value(1), .value(0), .value(0)])),
+        position: .value(1)
+    )
+]
+```
+
+### With token aliases
+
+```swift
+// Using color alias reference
+let brandGradient: GradientValue = [
+    GradientColor(
+        color: .alias(TokenPath("brand.primary")),
+        position: .value(0)
+    ),
+    GradientColor(
+        color: .alias(TokenPath("brand.secondary")),
+        position: .value(1)
+    )
+]
+```
+
+### JSON format
+
+```json
+{
+  "blue-to-red": {
+    "$type": "gradient",
+    "$value": [
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 1]
+          }
+        },
+        "position": 0
+      },
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [1, 0, 0]
+          }
+        },
+        "position": 1
+      }
+    ]
+  },
+  "mostly-yellow": {
+    "$type": "gradient",
+    "$value": [
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [1, 1, 0]
+          }
+        },
+        "position": 0.666
+      },
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [1, 0, 0]
+          }
+        },
+        "position": 1
+      }
+    ]
+  }
+}
+```
+
+## References
+
+[Gradient token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#gradient)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Number.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Number.md
@@ -1,0 +1,39 @@
+# ``NumberValue``
+
+## Examples
+
+### Direct values
+
+```swift
+// Decodes from: {"$value": 1.5, "$type": "number"}
+let lineHeight: NumberValue = 1.5
+
+// Decodes from: {"$value": 0.8, "$type": "number"}
+let opacity: NumberValue = 0.8
+
+// Decodes from: {"$value": 0.25, "$type": "number"}
+let gradientStop: NumberValue = 0.25
+```
+
+### JSON format
+
+```json
+{
+  "line-height-large": {
+    "$value": 1.5,
+    "$type": "number"
+  },
+  "opacity-subtle": {
+    "$value": 0.8,
+    "$type": "number"
+  },
+  "gradient-stop-quarter": {
+    "$value": 0.25,
+    "$type": "number"
+  }
+}
+```
+
+## References
+
+[Number token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#number)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Shadow.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Shadow.md
@@ -1,0 +1,130 @@
+# ``ShadowValue``
+
+## Examples
+
+### Single shadow
+
+```swift
+// Drop shadow
+let dropShadow = ShadowValue(
+    color: .value(try ColorValue(hex: "#000000")),
+    offsetX: .value(.constant(.init(value: 2, unit: .px))),
+    offsetY: .value(.constant(.init(value: 4, unit: .px))),
+    blur: .value(.constant(.init(value: 8, unit: .px))),
+    spread: .value(.constant(.init(value: 0, unit: .px)))
+)
+```
+
+### Inner shadow with alias
+
+```swift
+let innerShadow = ShadowValue(
+    color: .alias(TokenPath("shadow.inner.color")),
+    offsetX: .value(.constant(.init(value: 0, unit: .px))),
+    offsetY: .value(.constant(.init(value: 2, unit: .px))),
+    blur: .value(.constant(.init(value: 4, unit: .px))),
+    spread: .value(.constant(.init(value: -1, unit: .px))),
+    inset: true
+)
+```
+
+### Layered shadows
+
+```swift
+// Multiple shadows can be combined in an array
+let layered: [ShadowValue] = [
+    ShadowValue(
+        color: .value(ColorValue(colorSpace: .srgb, components: [.value(0), .value(0), .value(0)], alpha: 0.1)),
+        offsetX: .value(.constant(.init(value: 0, unit: .px))),
+        offsetY: .value(.constant(.init(value: 24, unit: .px))),
+        blur: .value(.constant(.init(value: 22, unit: .px))),
+        spread: .value(.constant(.init(value: 0, unit: .px)))
+    ),
+    ShadowValue(
+        color: .value(ColorValue(colorSpace: .srgb, components: [.value(0), .value(0), .value(0)], alpha: 0.2)),
+        offsetX: .value(.constant(.init(value: 0, unit: .px))),
+        offsetY: .value(.constant(.init(value: 42.9, unit: .px))),
+        blur: .value(.constant(.init(value: 44, unit: .px))),
+        spread: .value(.constant(.init(value: 0, unit: .px)))
+    )
+]
+```
+
+### JSON format
+
+```json
+{
+  "shadow-token": {
+    "$type": "shadow",
+    "$value": {
+      "color": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.5
+        }
+      },
+      "offsetX": { "value": 0.5, "unit": "rem" },
+      "offsetY": { "value": 0.5, "unit": "rem" },
+      "blur": { "value": 1.5, "unit": "rem" },
+      "spread": { "value": 0, "unit": "rem" }
+    }
+  },
+  "layered-shadow": {
+    "$type": "shadow",
+    "$value": [
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 0],
+            "alpha": 0.1
+          }
+        },
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": { "value": 24, "unit": "px" },
+        "blur": { "value": 22, "unit": "px" },
+        "spread": { "value": 0, "unit": "px" }
+      },
+      {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 0],
+            "alpha": 0.2
+          }
+        },
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": { "value": 42.9, "unit": "px" },
+        "blur": { "value": 44, "unit": "px" },
+        "spread": { "value": 0, "unit": "px" }
+      }
+    ]
+  },
+  "inner-shadow": {
+    "$type": "shadow",
+    "$value": {
+      "color": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.5
+        }
+      },
+      "offsetX": { "value": 2, "unit": "px" },
+      "offsetY": { "value": 2, "unit": "px" },
+      "blur": { "value": 4, "unit": "px" },
+      "spread": { "value": 0, "unit": "px" },
+      "inset": true
+    }
+  }
+}
+```
+
+## References
+
+[Shadow token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#shadow)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Transition.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Transition.md
@@ -1,0 +1,44 @@
+# ``TransitionValue``
+
+## Examples
+
+### Direct values
+
+```swift
+let emphasis = TransitionValue(
+    duration: .value(DurationValue(value: 200, unit: .millisecond)),
+    delay: .value(DurationValue(value: 0, unit: .millisecond)),
+    timingFunction: .value(CubicBezierValue(x1: 0.5, y1: 0, x2: 1, y2: 1))
+)
+```
+
+### With token aliases
+
+```swift
+let customTransition = TransitionValue(
+    duration: .alias(TokenPath("animation.duration.normal")),
+    delay: .value(DurationValue(value: 0, unit: .millisecond)),
+    timingFunction: .alias(TokenPath("animation.easing.emphasis"))
+)
+```
+
+### JSON format
+
+```json
+{
+  "transition": {
+    "emphasis": {
+      "$type": "transition",
+      "$value": {
+        "duration": { "value": 200, "unit": "ms" },
+        "delay": { "value": 0, "unit": "ms" },
+        "timingFunction": [0.5, 0, 1, 1]
+      }
+    }
+  }
+}
+```
+
+## References
+
+[Transition token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#transition)

--- a/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Typography.md
+++ b/Sources/SnappDesignTokens/SnappDesignTokens.docc/Tokens/Typography.md
@@ -1,0 +1,69 @@
+# ``TypographyValue``
+
+## Examples
+
+### Direct values
+
+```swift
+let heading = TypographyValue(
+    fontFamily: .value(FontFamilyValue("Roboto")),
+    fontSize: .value(.constant(.init(value: 42, unit: .px))),
+    fontWeight: .value(FontWeightValue(rawValue: 700)!),
+    letterSpacing: .value(.constant(.init(value: 0.1, unit: .px))),
+    lineHeight: .value(1.2)
+)
+```
+
+### With token aliases
+
+```swift
+let microcopy = TypographyValue(
+    fontFamily: .alias(TokenPath("font.serif")),
+    fontSize: .alias(TokenPath("font.size.smallest")),
+    fontWeight: .alias(TokenPath("font.weight.normal")),
+    letterSpacing: .value(.constant(.init(value: 0, unit: .px))),
+    lineHeight: .value(1)
+)
+```
+
+### JSON format
+
+```json
+{
+  "type styles": {
+    "heading-level-1": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Roboto",
+        "fontSize": {
+          "value": 42,
+          "unit": "px"
+        },
+        "fontWeight": 700,
+        "letterSpacing": {
+          "value": 0.1,
+          "unit": "px"
+        },
+        "lineHeight": 1.2
+      }
+    },
+    "microcopy": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "{font.serif}",
+        "fontSize": "{font.size.smallest}",
+        "fontWeight": "{font.weight.normal}",
+        "letterSpacing": {
+          "value": 0,
+          "unit": "px"
+        },
+        "lineHeight": 1
+      }
+    }
+  }
+}
+```
+
+## References
+
+[Typography token type documentation](https://www.designtokens.org/tr/third-editors-draft/format/#typography)

--- a/Sources/SnappDesignTokens/Token/Token.swift
+++ b/Sources/SnappDesignTokens/Token/Token.swift
@@ -65,7 +65,7 @@ public enum Token: DecodableWithConfiguration, Decodable,
     /// - Parameters:
     ///   - decoder: Decoder to read data from
     ///   - configuration: Configuration including parent type and custom mappings
-    /// - Throws: ``DecodingError`` if decoding fails
+    /// - Throws: `DecodingError` if decoding fails
     public init(
         from decoder: any Decoder,
         configuration: TokenDecodingConfiguration

--- a/Sources/SnappDesignTokens/Token/TokenArray.swift
+++ b/Sources/SnappDesignTokens/Token/TokenArray.swift
@@ -30,7 +30,7 @@ extension TokenArray {
     /// - Parameters:
     ///   - decoder: Decoder to read data from
     ///   - configuration: Parent configuration including inherited type and custom mappings
-    /// - Throws: ``DecodingError`` if array structure is invalid
+    /// - Throws: `DecodingError` if array structure is invalid
     init(
         from decoder: any Decoder,
         parentConfiguration configuration: TokenDecodingConfiguration

--- a/Sources/SnappDesignTokens/Token/TokenGroup.swift
+++ b/Sources/SnappDesignTokens/Token/TokenGroup.swift
@@ -31,7 +31,7 @@ extension TokenGroup {
     /// - Parameters:
     ///   - decoder: Decoder to read data from
     ///   - configuration: Parent configuration including inherited type and custom mappings
-    /// - Throws: ``DecodingError`` if group structure is invalid
+    /// - Throws: `DecodingError` if group structure is invalid
     init(
         from decoder: any Decoder,
         parentConfiguration configuration: TokenDecodingConfiguration

--- a/Sources/SnappDesignTokens/Token/TokenValue.swift
+++ b/Sources/SnappDesignTokens/Token/TokenValue.swift
@@ -64,7 +64,7 @@ public enum TokenValue: Decodable, DecodableWithConfiguration, Encodable,
     /// - Parameters:
     ///   - decoder: Decoder to read data from
     ///   - configuration: Configuration specifying token type and decoding options
-    /// - Throws: ``DecodingError`` if type is not specified or value structure is invalid
+    /// - Throws: `DecodingError` if type is not specified or value structure is invalid
     public init(
         from decoder: any Decoder,
         configuration: TokenValueDecodingConfiguration

--- a/Sources/SnappDesignTokens/Values/BorderValue.swift
+++ b/Sources/SnappDesignTokens/Values/BorderValue.swift
@@ -6,19 +6,10 @@
 
 import Foundation
 
-/// Represents a border token value with color, width, and stroke style.
+/// Represents a border with color, width, and stroke style properties.
 ///
-/// DTCG composite token combining three required sub-values. Each property
-/// supports both direct values and token aliases.
-///
-/// Example:
-/// ```swift
-/// let border = BorderValue(
-///     color: .value(.red),
-///     width: .value(.constant(.init(value: 3, unit: .px))),
-///     style: .value(.line(.solid))
-/// )
-/// ```
+/// Composite token combining three required sub-values. Each property
+/// supports both direct values and token aliases that reference other tokens.
 public struct BorderValue: Equatable, Codable, Sendable, CompositeToken {
     /// Border color as ``CompositeTokenValue`` of ``ColorValue``.
     public let color: CompositeTokenValue<ColorValue>

--- a/Sources/SnappDesignTokens/Values/ColorComponent.swift
+++ b/Sources/SnappDesignTokens/Values/ColorComponent.swift
@@ -38,7 +38,7 @@ public enum ColorComponent: Equatable, Sendable, Codable {
     /// Decodes a color component from numeric value or "none" string.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if value is neither numeric nor "none"
+    /// - Throws: `DecodingError` if value is neither numeric nor "none"
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         do {

--- a/Sources/SnappDesignTokens/Values/ColorValue.swift
+++ b/Sources/SnappDesignTokens/Values/ColorValue.swift
@@ -6,33 +6,12 @@
 
 import Foundation
 
-/// Represents a color token value across different color spaces.
+/// Represents a color across different color spaces.
 ///
-/// DTCG primitive token enabling standardized color representation and translation
-/// between design and development tools. Supports 13+ color spaces including sRGB,
-/// Display P3, HSL, Lab, and more. Components can use numeric values or the "none"
-/// keyword for missing channels.
-///
-/// Example:
-/// ```swift
-/// // Hex string format (sRGB)
-/// let red = try ColorValue(hex: "#FF0000")
-///
-/// // Structured format with color space
-/// let hslWhite = ColorValue(
-///     colorSpace: .hsl,
-///     components: [.none, 0, 100],
-///     alpha: 1,
-///     hex: "#ffffff"
-/// )
-///
-/// // Lab color space
-/// let labMagenta = ColorValue(
-///     colorSpace: .lab,
-///     components: [60.17, 93.54, -60.5],
-///     hex: "#ff00ff"
-/// )
-/// ```
+/// Supports 13+ color spaces including sRGB, Display P3, HSL, Lab, and more.
+/// Can decode from hex strings (e.g., `"#FF0000"`) or structured format with
+/// explicit color space and components. Components support numeric values or
+/// ``ColorComponent/none`` for missing channels.
 public struct ColorValue: Codable, EncodableWithConfiguration, Equatable,
     Sendable
 {
@@ -66,10 +45,10 @@ public struct ColorValue: Codable, EncodableWithConfiguration, Equatable,
     /// Per DTCG specification, defaults to 1.0 (fully opaque) when not specified.
     public let alpha: Double
 
-    /// Optional hex string fallback using CSS 6-digit notation.
+    /// Optional hex string using CSS notation (e.g., `"#FF0000"`).
     ///
-    /// Used for sRGB colors (e.g., `"#FF0000"` for red) or as closest sRGB approximation
-    /// for other color spaces. Preserved during round-trip encoding/decoding.
+    /// For sRGB colors or closest sRGB approximation for other color spaces.
+    /// Preserved during round-trip encoding/decoding.
     public let hex: String?
 
     /// Creates a color value with the specified color space and components.
@@ -91,6 +70,13 @@ public struct ColorValue: Codable, EncodableWithConfiguration, Equatable,
         self.hex = hex
     }
 
+    /// Decodes a color from structured format or hex string.
+    ///
+    /// Attempts structured decoding first (color space + components), falling back
+    /// to hex string format.
+    ///
+    /// - Parameter decoder: Decoder to read data from
+    /// - Throws: `DecodingError` if format is invalid or hex string is malformed
     public init(from decoder: any Decoder) throws {
         do {
             let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/SnappDesignTokens/Values/CompositeTokenValue.swift
+++ b/Sources/SnappDesignTokens/Values/CompositeTokenValue.swift
@@ -38,7 +38,7 @@ where Value: Codable, Value: Equatable, Value: Sendable {
     /// Attempts to decode as ``TokenPath`` first (alias), falling back to direct value.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if neither alias nor value decoding succeeds
+    /// - Throws: `DecodingError` if neither alias nor value decoding succeeds
     public init(from decoder: any Decoder)
         throws
     {

--- a/Sources/SnappDesignTokens/Values/CubicBezierValue.swift
+++ b/Sources/SnappDesignTokens/Values/CubicBezierValue.swift
@@ -36,21 +36,9 @@ public struct CubicBezierValueDecodingError: Error, Equatable {
 
 /// Represents a cubic Bézier animation timing curve.
 ///
-/// DTCG primitive token defining how an animated property progresses during animation.
-/// Controls acceleration, deceleration, and other timing effects using two control points.
-///
-/// Per DTCG specification, the curve is defined by four values `[x1, y1, x2, y2]` where:
-/// - X coordinates (x1, x2) must be in range [0, 1]
-/// - Y coordinates (y1, y2) can be any real number
-///
-/// Example:
-/// ```swift
-/// // Accelerate curve
-/// let accelerate = CubicBezierValue(x1: 0.5, y1: 0, x2: 1, y2: 1)
-///
-/// // Decelerate curve
-/// let decelerate = CubicBezierValue(x1: 0, y1: 0, x2: 0.5, y2: 1)
-/// ```
+/// Defines how an animated property progresses using two control points.
+/// Decodes from 4-element array `[x1, y1, x2, y2]` where X coordinates must be
+/// in range [0, 1] and Y coordinates can be any real number.
 public struct CubicBezierValue: Equatable, Codable, Sendable {
     private static let xRange: ClosedRange<Double> = 0...1
 

--- a/Sources/SnappDesignTokens/Values/CubicBezierValue.swift
+++ b/Sources/SnappDesignTokens/Values/CubicBezierValue.swift
@@ -93,7 +93,7 @@ public struct CubicBezierValue: Equatable, Codable, Sendable {
     /// Expects format `[x1, y1, x2, y2]` and validates constraints per DTCG specification.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if value is not an array or ``CubicBezierValueDecodingError`` if array length is invalid or X values out of range
+    /// - Throws: `DecodingError` if value is not an array or ``CubicBezierValueDecodingError`` if array length is invalid or X values out of range
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let values = try container.decode([Double].self)

--- a/Sources/SnappDesignTokens/Values/DimensionValue.swift
+++ b/Sources/SnappDesignTokens/Values/DimensionValue.swift
@@ -50,7 +50,7 @@ public enum DimensionValue: Codable, Equatable, Sendable {
     /// Attempts to decode as ``DimensionConstant`` first, falling back to ``DimensionExpression``.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if neither format succeeds
+    /// - Throws: `DecodingError` if neither format succeeds
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         let constantValue = try? container.decode(DimensionConstant.self)

--- a/Sources/SnappDesignTokens/Values/DurationValue.swift
+++ b/Sources/SnappDesignTokens/Values/DurationValue.swift
@@ -8,16 +8,6 @@ import Foundation
 
 /// Represents a time duration for animations and transitions.
 ///
-/// DTCG primitive token type for measuring animation timing, transition delays, and
-/// other time-based values. This is a ``TokenMeasurement`` specialized for
-/// ``DurationUnit`` (s, ms).
-///
-/// Example:
-/// ```swift
-/// // 100 milliseconds
-/// let quick = DurationValue(value: 100, unit: .millisecond)
-///
-/// // 1.5 seconds
-/// let long = DurationValue(value: 1.5, unit: .second)
-/// ```
+/// Used for animation timing, transition delays, and other time-based values.
+/// Specialization of ``TokenMeasurement`` for ``DurationUnit`` (seconds, milliseconds).
 public typealias DurationValue = TokenMeasurement<DurationUnit>

--- a/Sources/SnappDesignTokens/Values/FileValue.swift
+++ b/Sources/SnappDesignTokens/Values/FileValue.swift
@@ -69,7 +69,7 @@ public struct FileValue: DecodableWithConfiguration, Decodable,
     /// - Parameters:
     ///   - decoder: Decoder to read data from
     ///   - configuration: Optional configuration with source location for resolving relative paths
-    /// - Throws: ``DecodingError`` if value is not a string or ``FileValueDecodingError/invalidURL(_:)`` if string is not a valid URL
+    /// - Throws: `DecodingError.typeMismatch` if the encountered stored value is  not a single value container, `DecodingError.valueNotFound` if value is not a string or ``FileValueDecodingError/invalidURL(_:)`` if string is not a valid URL
     public init(
         from decoder: any Decoder,
         configuration: FileValueDecodingConfiguration?
@@ -108,7 +108,7 @@ public struct FileValue: DecodableWithConfiguration, Decodable,
     /// - Parameters:
     ///   - encoder: Encoder to write data to
     ///   - configuration: URL encoding format (absolute or relative)
-    /// - Throws: ``EncodingError`` if URL cannot be encoded in the specified format
+    /// - Throws: `EncodingError.invalidValue` if URL cannot be encoded in the specified format
     public func encode(
         to encoder: any Encoder,
         configuration: FileValueEncodingConfiguration

--- a/Sources/SnappDesignTokens/Values/FontFamilyValue.swift
+++ b/Sources/SnappDesignTokens/Values/FontFamilyValue.swift
@@ -6,18 +6,8 @@
 
 /// Represents a font family token value with optional fallbacks.
 ///
-/// DTCG primitive token for specifying font names with prioritized fallback list.
-/// Supports single font name or array of names ordered from most to least preferred,
-/// ensuring typography consistency across platforms.
-///
-/// Example:
-/// ```swift
-/// // Single font
-/// let primary: FontFamilyValue = "Comic Sans MS"
-///
-/// // Font stack with fallbacks
-/// let body = FontFamilyValue("Helvetica", "Arial", "sans-serif")
-/// ```
+/// Supports single font name or array of names ordered from most to least preferred.
+/// Values decode from either string or string array as shown in DTCG specification.
 public struct FontFamilyValue: Codable, Equatable, Sendable, ExpressibleByStringLiteral {
     /// Font names ordered from most to least preferred.
     public let names: [String]

--- a/Sources/SnappDesignTokens/Values/FontFamilyValue.swift
+++ b/Sources/SnappDesignTokens/Values/FontFamilyValue.swift
@@ -27,7 +27,7 @@ public struct FontFamilyValue: Codable, Equatable, Sendable, ExpressibleByString
     /// Attempts array decoding first, falling back to single string.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if value is neither string nor string array
+    /// - Throws: `DecodingError` if value is neither string nor string array
     public init(from decoder: any Decoder) throws {
         do {
             let names = try [String](from: decoder)

--- a/Sources/SnappDesignTokens/Values/FontWeightValue.swift
+++ b/Sources/SnappDesignTokens/Values/FontWeightValue.swift
@@ -15,20 +15,11 @@ public enum FontWeightValueDecodingError: Error, Equatable {
     case invalidAlias(String)
 }
 
-/// Represents a font weight token value.
+/// Represents a font weight using numeric values or named aliases.
 ///
-/// DTCG primitive token for font weight (thickness) using numeric values (1-1000) or
-/// named aliases. Per DTCG specification, values outside 1-1000 are invalid and must
-/// be rejected.
-///
-/// Example:
-/// ```swift
-/// // Numeric weight
-/// let custom = FontWeightValue(rawValue: 350)
-///
-/// // Named alias
-/// let bold = FontWeightValue(alias: .bold)
-/// ```
+/// Supports numeric values (1-1000) or named aliases like "bold" or "extra-light".
+/// Decodes from either number or string. Values outside 1-1000 are rejected per
+/// DTCG specification.
 public struct FontWeightValue: RawRepresentable, Codable, Equatable,
     Sendable
 {
@@ -36,8 +27,7 @@ public struct FontWeightValue: RawRepresentable, Codable, Equatable,
 
     /// Named aliases for common font weights.
     ///
-    /// DTCG-defined keywords mapping to specific numeric values. Aliases are case-sensitive
-    /// and must match exactly during decoding.
+    /// DTCG-defined keywords mapping to specific numeric values. Case-sensitive.
     public enum Alias: String, CaseIterable, Equatable, Sendable {
         /// Thin weight (100).
         case thin, hairline

--- a/Sources/SnappDesignTokens/Values/FontWeightValue.swift
+++ b/Sources/SnappDesignTokens/Values/FontWeightValue.swift
@@ -134,7 +134,7 @@ public struct FontWeightValue: RawRepresentable, Codable, Equatable,
     /// Attempts numeric decoding first, falling back to alias lookup.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if value is neither number nor string, ``FontWeightValueDecodingError`` if value/alias is invalid
+    /// - Throws: `DecodingError` if value is neither number nor string, ``FontWeightValueDecodingError`` if value/alias is invalid
     public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let rawValue = try? container.decode(UInt.self) {

--- a/Sources/SnappDesignTokens/Values/GradientColor.swift
+++ b/Sources/SnappDesignTokens/Values/GradientColor.swift
@@ -8,27 +8,9 @@ import Foundation
 
 /// Represents a single color stop in a gradient.
 ///
-/// Used within ``GradientValue`` to define color transitions. Each stop specifies a color
-/// and its position along the gradient axis (0-1 range, where 0 is start and 1 is end).
-/// Both properties support direct values and token aliases.
-///
-/// Per DTCG specification, positions outside [0, 1] are clamped. If no stops exist at
-/// 0 or 1, the closest color extends to that end.
-///
-/// Example:
-/// ```swift
-/// // Stop at start
-/// let blueStart = GradientColor(
-///     color: .value(.blue),
-///     position: .value(0)
-/// )
-///
-/// // Stop at end using alias
-/// let redEnd = GradientColor(
-///     color: .alias(TokenPath("brand-primary")),
-///     position: .value(1)
-/// )
-/// ```
+/// Used within ``GradientValue`` to define color transitions. Each stop specifies
+/// a color and position (0-1, where 0 is start and 1 is end). Both properties
+/// support direct values and token aliases.
 public struct GradientColor: Equatable, Sendable, Codable {
     /// Color at this gradient stop as ``CompositeTokenValue`` of ``ColorValue``.
     public let color: CompositeTokenValue<ColorValue>

--- a/Sources/SnappDesignTokens/Values/NumberValue.swift
+++ b/Sources/SnappDesignTokens/Values/NumberValue.swift
@@ -4,16 +4,8 @@
 //  Created by Volodymyr Voiko on 27.03.2025.
 //
 
-/// Represents a unitless numeric token value.
+/// Represents a unitless numeric value.
 ///
-/// DTCG primitive token for generic numeric values without specific units. Used for
-/// line heights, gradient stop positions, opacity values, and other unitless measurements.
-/// Distinct from dimension tokens which include units like px or rem.
-///
-/// Example:
-/// ```swift
-/// let lineHeight: NumberValue = 1.5
-/// let opacity: NumberValue = 0.8
-/// let gradientStop: NumberValue = 0.25
-/// ```
+/// Used for line heights, gradient stop positions, opacity, and other unitless
+/// measurements. Distinct from ``DimensionValue`` which includes units like px or rem.
 public typealias NumberValue = Double

--- a/Sources/SnappDesignTokens/Values/ShadowValue.swift
+++ b/Sources/SnappDesignTokens/Values/ShadowValue.swift
@@ -6,60 +6,37 @@
 
 import Foundation
 
-/// Represents a single shadow layer.
+/// Represents a single shadow layer for drop or inner shadows.
 ///
-/// DTCG composite token defining drop shadows and inner shadows. Multiple ``ShadowValue``
-/// instances can be layered to create complex shadow effects. Each property supports both
-/// direct values and token aliases.
-///
-/// Example:
-/// ```swift
-/// // Drop shadow
-/// let dropShadow = ShadowValue(
-///     color: .value(try ColorValue(hex: "#000000")),
-///     offsetX: .value(DimensionValue(value: 2, unit: .px)),
-///     offsetY: .value(DimensionValue(value: 4, unit: .px)),
-///     blur: .value(DimensionValue(value: 8, unit: .px)),
-///     spread: .value(DimensionValue(value: 0, unit: .px))
-/// )
-///
-/// // Inner shadow
-/// let innerShadow = ShadowValue(
-///     color: .alias(TokenPath("shadow.inner.color")),
-///     offsetX: .value(DimensionValue(value: 0, unit: .px)),
-///     offsetY: .value(DimensionValue(value: 2, unit: .px)),
-///     blur: .value(DimensionValue(value: 4, unit: .px)),
-///     spread: .value(DimensionValue(value: -1, unit: .px)),
-///     inset: true
-/// )
-/// ```
+/// Defines shadow appearance with color, offsets, blur, and spread. Multiple instances
+/// can be layered for complex effects. All properties support direct values and token aliases.
 public struct ShadowValue: Codable, Equatable, Sendable, CompositeToken {
     /// Shadow color as ``CompositeTokenValue`` of ``ColorValue``.
     public let color: CompositeTokenValue<ColorValue>
 
     /// Horizontal shadow offset as ``CompositeTokenValue`` of ``DimensionValue``.
     ///
-    /// Positive values move shadow right, negative values move left.
+    /// Positive moves right, negative moves left.
     public let offsetX: CompositeTokenValue<DimensionValue>
 
     /// Vertical shadow offset as ``CompositeTokenValue`` of ``DimensionValue``.
     ///
-    /// Positive values move shadow down, negative values move up.
+    /// Positive moves down, negative moves up.
     public let offsetY: CompositeTokenValue<DimensionValue>
 
     /// Blur radius as ``CompositeTokenValue`` of ``DimensionValue``.
     ///
-    /// Higher values create more blur, 0 creates sharp shadow.
+    /// Higher values create more blur. Zero creates sharp shadow.
     public let blur: CompositeTokenValue<DimensionValue>
 
     /// Shadow expansion/contraction as ``CompositeTokenValue`` of ``DimensionValue``.
     ///
-    /// Positive values expand shadow, negative values contract it.
+    /// Positive expands shadow, negative contracts it.
     public let spread: CompositeTokenValue<DimensionValue>
 
-    /// Whether shadow renders inside the container (inner shadow).
+    /// Whether shadow renders inside the container.
     ///
-    /// When `true`, creates inner shadow. When `false` or `nil` (default), creates drop shadow.
+    /// `true` for inner shadow, `false` or `nil` (default) for drop shadow.
     public let inset: Bool?
 
     /// Creates a shadow with the specified properties.

--- a/Sources/SnappDesignTokens/Values/ShadowValue.swift
+++ b/Sources/SnappDesignTokens/Values/ShadowValue.swift
@@ -90,7 +90,7 @@ public struct ShadowValue: Codable, Equatable, Sendable, CompositeToken {
     /// Decodes all shadow properties.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if any required property is missing or invalid
+    /// - Throws: `DecodingError` if any required property is missing or invalid
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.color = try container.decode(CompositeTokenValue<ColorValue>.self, forKey: .color)
@@ -130,7 +130,7 @@ public struct ShadowValue: Codable, Equatable, Sendable, CompositeToken {
     /// Encodes all shadow properties.
     ///
     /// - Parameter encoder: Encoder to write data to
-    /// - Throws: ``EncodingError`` if any values are invalid for the given encoder's format
+    /// - Throws: `EncodingError.invalidValue` if any values are invalid for the given encoder's format
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.color, forKey: .color)

--- a/Sources/SnappDesignTokens/Values/TokenCollection.swift
+++ b/Sources/SnappDesignTokens/Values/TokenCollection.swift
@@ -41,7 +41,7 @@ extension TokenCollection: Decodable where Value: Decodable {
     /// Attempts array decoding first, falling back to single value if array decoding fails.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if value cannot be decoded as either array or single value
+    /// - Throws: `DecodingError` if value cannot be decoded as either array or single value
     public init(from decoder: any Decoder) throws {
         do {
             self.values = try [Value](from: decoder)
@@ -57,7 +57,7 @@ extension TokenCollection: Encodable where Value: Encodable {
     /// Encodes single-element collections as unwrapped value, multi-element as array.
     ///
     /// - Parameter encoder: Encoder to write data to
-    /// - Throws: ``EncodingError`` if encoding fails
+    /// - Throws: `EncodingError.invalidValue` if encoding fails
     public func encode(to encoder: any Encoder) throws {
         if values.count == 1 {
             try values[0].encode(to: encoder)

--- a/Sources/SnappDesignTokens/Values/TokenMeasurement.swift
+++ b/Sources/SnappDesignTokens/Values/TokenMeasurement.swift
@@ -54,7 +54,7 @@ where T: UnitType {
     /// with separate `value` and `unit` properties.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if decoding fails
+    /// - Throws: `DecodingError` if decoding fails
     public init(from decoder: any Decoder) throws {
         if let decoded = try T.decode(decoder) {
             self = decoded

--- a/Sources/SnappDesignTokens/Values/TransitionValue.swift
+++ b/Sources/SnappDesignTokens/Values/TransitionValue.swift
@@ -8,25 +8,16 @@ import Foundation
 
 /// Represents an animated transition between two states.
 ///
-/// DTCG composite token defining transition timing with three required properties. Each
-/// property supports both direct values and token aliases.
-///
-/// Example:
-/// ```swift
-/// let emphasis = TransitionValue(
-///     duration: .value(.init(value: 200, unit: .millisecond)),
-///     delay: .value(.init(value: 0, unit: .millisecond)),
-///     timingFunction: .value(.init(x1: 0.5, y1: 0, x2: 1, y2: 1))
-/// )
-/// ```
+/// Defines transition timing with duration, delay, and timing function. All properties
+/// support direct values and token aliases.
 public struct TransitionValue: Equatable, Sendable, Codable, CompositeToken {
-    /// Transition length as ``CompositeTokenValue`` of ``DurationValue``.
+    /// Transition duration as ``CompositeTokenValue`` of ``DurationValue``.
     public let duration: CompositeTokenValue<DurationValue>
 
-    /// Wait time before transition starts as ``CompositeTokenValue`` of ``DurationValue``.
+    /// Delay before transition starts as ``CompositeTokenValue`` of ``DurationValue``.
     public let delay: CompositeTokenValue<DurationValue>
 
-    /// Animation curve as ``CompositeTokenValue`` of ``CubicBezierValue``.
+    /// Timing curve as ``CompositeTokenValue`` of ``CubicBezierValue``.
     public let timingFunction: CompositeTokenValue<CubicBezierValue>
 
     /// Creates a transition with the specified timing properties.

--- a/Sources/SnappDesignTokens/Values/TypographyValue.swift
+++ b/Sources/SnappDesignTokens/Values/TypographyValue.swift
@@ -8,19 +8,8 @@ import Foundation
 
 /// Represents a complete typographic style.
 ///
-/// DTCG composite token combining five required text-related properties. Each property
-/// supports both direct values and token aliases for flexible design system composition.
-///
-/// Example:
-/// ```swift
-/// let heading = TypographyValue(
-///     fontFamily: .value(.init("Helvetica")),
-///     fontSize: .value(.constant(.init(value: 16, unit: .px))),
-///     fontWeight: .value(.bold),
-///     letterSpacing: .value(.constant(.init(value: 0.1, unit: .px))),
-///     lineHeight: .value(1.2)
-/// )
-/// ```
+/// Combines five text-related properties: font family, size, weight, letter spacing,
+/// and line height. All properties support direct values and token aliases.
 public struct TypographyValue: Codable, Equatable, Sendable, CompositeToken {
     /// Font family as ``CompositeTokenValue`` of ``FontFamilyValue``.
     public let fontFamily: CompositeTokenValue<FontFamilyValue>
@@ -39,7 +28,7 @@ public struct TypographyValue: Codable, Equatable, Sendable, CompositeToken {
     /// Interpreted as a multiplier of the font size.
     public let lineHeight: CompositeTokenValue<NumberValue>
 
-    /// Decodes all five typography properties.
+    /// Decodes all typography properties.
     ///
     /// - Parameter decoder: Decoder to read data from
     /// - Throws: `DecodingError` if any required property is missing or invalid

--- a/Sources/SnappDesignTokens/Values/TypographyValue.swift
+++ b/Sources/SnappDesignTokens/Values/TypographyValue.swift
@@ -42,7 +42,7 @@ public struct TypographyValue: Codable, Equatable, Sendable, CompositeToken {
     /// Decodes all five typography properties.
     ///
     /// - Parameter decoder: Decoder to read data from
-    /// - Throws: ``DecodingError`` if any required property is missing or invalid
+    /// - Throws: `DecodingError` if any required property is missing or invalid
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.fontFamily = try container.decode(

--- a/Sources/SnappDesignTokens/Values/UnitType.swift
+++ b/Sources/SnappDesignTokens/Values/UnitType.swift
@@ -40,7 +40,7 @@ where RawValue == String {
     ///
     /// - Parameter decoder: Decoder to read data from
     /// - Returns: Decoded ``TokenMeasurement``, or `nil` to fall back to standard decoding
-    /// - Throws: ``DecodingError`` if custom decoding fails
+    /// - Throws: `DecodingError` if custom decoding fails
     static func decode(_ decoder: any Decoder) throws -> TokenMeasurement<Self>?
 }
 


### PR DESCRIPTION
## What
Added comprehensive DocC documentation for design token types and core evaluation components.

## Why
To provide clear, consistent API documentation following Apple's DocC standards, making the library easier to understand and use for developers working with DTCG design tokens.

## Changes
Only to documentation files

## Screenshots

### Token's documentation update
<img width="1284" height="1480" alt="Screenshot 2025-10-07 at 5 56 33 PM" src="https://github.com/user-attachments/assets/696ba314-0af0-48f5-ba99-ed683d299f38" />

### Article -`DesignTokens` - name may be updated
<img width="1557" height="1599" alt="Screenshot 2025-10-07 at 5 55 19 PM" src="https://github.com/user-attachments/assets/7b3830c1-8a1b-4a5c-98aa-8d7a83667d92" />

### Main screen update - concise
<img width="1284" height="764" alt="Screenshot 2025-10-07 at 5 56 19 PM" src="https://github.com/user-attachments/assets/687817ab-e976-4c39-abb0-9740ac6922e4" />
