### PR TITLE
Doc link for swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://ios-theming.snappmobile.io/documentation/snappdesigntokens/"


### PR DESCRIPTION
## What
Documentation URL for Swift Package Index 

## Why
To have documentation button there

## Changes
add `.spi.yml`

### More info 

<img width="217" height="143" alt="Screenshot 2025-11-25 at 9 27 56 AM" src="https://github.com/user-attachments/assets/2cf81ea8-1aa3-4742-b3c2-1446e5e4791a" />


[Configure-a-documentation-URL-for-existing-documentation](https://swiftpackageindex.com/swiftpackageindex/spimanifest/1.11.0/documentation/spimanifest/commonusecases#Configure-a-documentation-URL-for-existing-documentation)
